### PR TITLE
feat: add an option to enable/disable plugin when in dev mode

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -5,12 +5,18 @@ module.exports = function facebookPixelModule (moduleOptions) {
     pixelId: null,
     track: 'PageView',
     version: '2.0',
-    disabled: false
+    disabled: false,
+    debug: false
   }
 
   const options = Object.assign({}, defaults, this.options.facebook, moduleOptions)
 
   if (!options.pixelId) throw new Error('The `pixelId` option is required.')
+
+  // Don't include when run in dev mode unless debug: true is configured
+  if (this.options.dev && !options.debug) {
+    return
+  }
 
   this.addPlugin({
     src: path.resolve(__dirname, './templates/plugin.js'),


### PR DESCRIPTION
I think it is better if the facebook tracking don't start when we're in dev mode unless we want it.