### PR TITLE
fix: include Fb plugin even not in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ List of possible options in the module:
 | track    | PageView | false    | Default tracking event.                                                                   |
 | version  | 2.0      | false    | Tracking version.                                                                         |
 | disabled | false    | false    | Disable the Pixel by default when initialized. Can be enabled later through `$fb.enable()` and disabled again with `$fb.disable()`.
-| manualMode | false    | false    | By default, Facebook will trigger button click and page metadata. Set to `true` to disable this behaviour. [See more informations](https://developers.facebook.com/docs/facebook-pixel/advanced/#automatic-configuration)
+| debug | false    | false    | By default, tracking in development mode is disabled. By specifying `true`, you manually allow tracking in development mode.
+| manualModef | false    | false    | By default, Facebook will trigger button click and page metadata. Set to `true` to disable this behaviour. [See more informations](https://developers.facebook.com/docs/facebook-pixel/advanced/#automatic-configuration)
 | autoPageView | false    | false    | If set to `true`, automatically triggers a `PageView` track event on every page change.
 | pixels | []    | false    | An array of pixels be used according to a specific set of routes. See [Multiple pixel codes according to route](#multiple-pixel-codes-according-to-route)
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -13,17 +13,13 @@ const DEFAULT_OPTIONS = {
 
 module.exports = function facebookPixelModule (moduleOptions) {
   const options = Object.assign({}, DEFAULT_OPTIONS, this.options.facebook, moduleOptions)
+  options.dev = this.options.dev
 
   if (options.pixels && options.pixels.length > 0) {
     options.pixels = options.pixels.map(option => Object.assign({}, DEFAULT_OPTIONS, option))
   }
 
   if (!options.pixelId) throw new Error('The default `pixelId` option is required.')
-
-  // Don't include when run in dev mode unless debug: true is configured
-  if (this.options.dev && !options.debug) {
-    return
-  }
 
   this.addPlugin({
     src: path.resolve(__dirname, './templates/plugin.js'),

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -57,6 +57,7 @@ class Fb {
    * @param {object} parameters
    */
   query (cmd, option, parameters = null) {
+    if (this.options.debug) log('Command:', cmd, 'Option:', option, 'Additional parameters:', parameters)
     if (!this.isEnabled) return
 
     if (!parameters) {
@@ -78,9 +79,16 @@ function getMatchingPixel (options, path) {
   })
 }
 
+function log (...messages) {
+  console.info.apply(this, ['[nuxt-facebook-pixel-module]', ...messages])
+}
+
 export default (ctx, inject) => {
   let _fbq
   const parsedOptions = <%= JSON.stringify(options) %>
+  const isDev = parsedOptions.dev && !parsedOptions.debug
+
+  if (isDev) log('You are running in development mode. Set "debug: true" in your nuxt.config.js if you would like to trigger tracking events in local.')
 
   const { path } = ctx.route
   const matchingPixel = getMatchingPixel(parsedOptions, path)
@@ -105,7 +113,7 @@ export default (ctx, inject) => {
 
       _fbq = fbq;
 
-      if (!pixelOptions.disabled) {
+      if (!isDev && !pixelOptions.disabled) {
         if (pixelOptions.manualMode) {
           fbq('set', 'autoConfig', false, pixelOptions.pixelId)
         }


### PR DESCRIPTION
Include the Fb plugin even if the user is not in debug mode.
This also includes a console message about this parameter.

fixes #26 