### PR TITLE
feat: add support for user data in fb init function

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ Per this example, whenever the user is on the `/my-custom-route`, it will use th
 
 Note : Since the `pixels` property is an array of options, any other valid option (`track`, `manualMode`, ...) can be passed.
 
+# Advanced Matching
+To send custom user data when initializing the FB Pixel you'll have to disable the plugin in your Nuxt config file and enable it once you've set the user data.
+
+Run the following from your Vue component once you've access to the user data:
+```javascript
+this.$fb.setUserData({ external_id: 32323, fn: 'John' })
+this.$fb.enable()
+```
+
+Read more about [Advanced Matching](https://developers.facebook.com/docs/facebook-pixel/advanced/advanced-matching).
+
 ## Module options
 
 List of possible options in the module:
@@ -161,6 +172,7 @@ The tracking pixel instance is available on all vue component instances as $fb. 
 | enable()          | If you had previously set `disabled: true` in config, enables the pixel and tracks the current page view | $fb.init(), $fb.track()        |
 | disable()          | Disables the pixel again |         |
 | setPixelId()            | Change the default pixelId & trigger an init it                                                                                    | |
+| setUserData(userData) | Used to set user data that'll be used once the `fbq` init function is called. See [Advanced Matching](https://developers.facebook.com/docs/facebook-pixel/advanced/advanced-matching). | |
 | init()            | Initialises the pixel                                                                                    | fbq('init', <options.pixelId>) |
 | track(event, parameters)           | Sends a track event with optional `parameters`. It's `PageView` by default if the `event` is not defined.                                                                                      | fbq('track', <options.track>, parameters)  |
 | query(key, value, parameters) | Call the underlying fbq instance with anything else. The `parameters` attribute is optional.                                                      | fbq(key, value, parameters)                |

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,11 +41,26 @@ interface FacebookEventParameters {
     value?: number; // The value of a user performing this event to the business.
 }
 
+interface FacebookUserData {
+  em?: string // Email jsmith@example.com
+  fn?: string // First name Lowercase letters
+  ln?: string // Last name Lowercase letters
+  ph?: number // Phone Digits only including country code and area code 16505554444
+  ID?: string | number // External external_id Any unique ID from the advertiser, such as loyalty membership ID, user ID, and external cookie
+  ge?: 'f' | 'm' // Gender Single lowercase letter, f or m, if unknown, leave blank
+  db?: number // Birthdate Digits only with birth year, month, then day 19910526 for May 26, 1991.
+  ct?: string // City Lowercase with any spaces removed
+  or?: string // State Province st Lowercase two - letter state or province code ca
+  or?: number // Zip Postal Code zp Digits only 94025
+  country?: string // Country Lowercase two - letter country code us
+}
+
 interface NuxtFacebookPixel {
     enable(): void;
     disable(): void;
     init(): void;
     setPixelId(pixelId: string): void;
+    setUserData(userData?: FacebookUserData): void;
     track(event: null | FacebookEvent, parameters?: FacebookEventParameters): void;
     query<T extends object>(key: string, value: string, parameters?: T): void;
 }

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -17,6 +17,15 @@ class Fb {
   }
 
   /**
+   * @method setUserData
+   * Used to set user data that'll be used once the `fbq` init function is called.
+   * @param {object} [userData] See https://developers.facebook.com/docs/facebook-pixel/advanced/advanced-matching#reference
+   */
+  setUserData(userData) {
+    this.userData = userData
+  }
+
+  /**
    * @method enable
    */
   enable () {
@@ -36,7 +45,7 @@ class Fb {
    * @method init
    */
   init () {
-    this.query('init', this.options.pixelId)
+    this.query('init', this.options.pixelId, this.userData || undefined)
   }
 
   /**


### PR DESCRIPTION
The `fbq` init function can be used to set custom user data for [Advanced Matching](https://developers.facebook.com/docs/facebook-pixel/advanced/advanced-matching).
This feature adds support for setting this through a new `setUserData` method that'll be used once `init` is called.